### PR TITLE
fix nn.init deprecation warning

### DIFF
--- a/models.py
+++ b/models.py
@@ -372,7 +372,7 @@ class MCNN(TorchModel):
     def init_parameters(self):
         for module in self.modules():
             if isinstance(module, nn.Conv2d) or isinstance(module, nn.Linear):
-                nn.init.xavier_uniform(module.weight)
+                nn.init.xavier_uniform_(module.weight)
                 nn.init.constant_(module.bias, 0)
     
     def forward(self, x):


### PR DESCRIPTION
Fixed deprecation warning (`nn.init.xavier_uniform` deprecated in favor of `nn.init.xavier_uniform_`) that occurs for versions of PyTorch starting with 0.4.